### PR TITLE
Improve the testing script workflow.

### DIFF
--- a/codeHF/CompareNew.C
+++ b/codeHF/CompareNew.C
@@ -1,4 +1,4 @@
-Bool_t CompareNew(TString filerun3="AnalysisResults.root", TString filerun1="Vertices2prong-ITS1.root", double mass=1.8){
+Int_t CompareNew(TString filerun3="AnalysisResults.root", TString filerun1="Vertices2prong-ITS1.root", double mass=1.8){
 
   gROOT->SetStyle("Plain");	
   gStyle->SetOptStat(0);
@@ -64,8 +64,5 @@ Bool_t CompareNew(TString filerun3="AnalysisResults.root", TString filerun1="Ver
     legend->Draw();
   }
   cv->SaveAs("optimisedcomp.pdf");
-  return true; 
+  return 0;
 }
-
-
-

--- a/codeHF/ComputeVerticesRun1_Opt.C
+++ b/codeHF/ComputeVerticesRun1_Opt.C
@@ -210,7 +210,7 @@ AliAODRecoDecayHF3Prong* Make3Prong(TObjArray *threeTrackArray, AliAODVertex *se
   return the3Prong;
 }
 
-Bool_t ComputeVerticesRun1_Opt(TString esdfile = "AliESDs.root",
+Int_t ComputeVerticesRun1_Opt(TString esdfile = "AliESDs.root",
 			       TString output = "Vertices23prong-ITS1.root",
 			       TString jsonconfig = "dpl-config_std.json",
 			       double ptmintrack=0.,
@@ -220,14 +220,14 @@ Bool_t ComputeVerticesRun1_Opt(TString esdfile = "AliESDs.root",
   TFile* esdFile = TFile::Open(esdfile.Data());
   if (!esdFile || !esdFile->IsOpen()) {
     printf("Error in opening ESD file");
-    return kFALSE;
+    return 1;
   }
   
   AliESDEvent * esd = new AliESDEvent;
   TTree* tree = (TTree*) esdFile->Get("esdTree");
   if (!tree) {
     printf("Error: no ESD tree found");
-    return kFALSE;
+    return 1;
   }
   esd->ReadFromTree(tree);
 
@@ -288,7 +288,7 @@ Bool_t ComputeVerticesRun1_Opt(TString esdfile = "AliESDs.root",
     tree->GetEvent(iEvent);
     if (!esd) {
       printf("Error: no ESD object found for event %d", iEvent);
-      return kFALSE;
+      return 1;
     }
     TString trClass=esd->GetFiredTriggerClasses();
     if(triggerstring != "" && !trClass.Contains(triggerstring)) continue;
@@ -300,7 +300,7 @@ Bool_t ComputeVerticesRun1_Opt(TString esdfile = "AliESDs.root",
     Int_t totTracks=TMath::Min(maxTracksToProcess,esd->GetNumberOfTracks());
 
     AliESDVertex *primvtx = (AliESDVertex*)esd->GetPrimaryVertex();
-    if(!primvtx) return kFALSE;
+    if(!primvtx) return 1;
     TString title=primvtx->GetTitle();
     if(primvtx->IsFromVertexer3D() || primvtx->IsFromVertexerZ()) continue;
     if(primvtx->GetNContributors()<2) continue;
@@ -485,5 +485,5 @@ Bool_t ComputeVerticesRun1_Opt(TString esdfile = "AliESDs.root",
   hptprong1->Write();
 
   fout->Close();
-  return true; 
+  return 0;
 }

--- a/codeHF/clean.sh
+++ b/codeHF/clean.sh
@@ -1,10 +1,13 @@
-rm *.root
-rm AnalysisR*.root
-rm *.txt
-rm output*
-#rm *.root
-rm *.pdf
-rm localhost*
+#!/bin/bash
+
+echo "Cleaning"
+
+rm -f *.root
+rm -f *.txt
+rm -f output*
+rm -f *.pdf
+rm -f localhost*
 git checkout cv_K0star.pdf
 git checkout cvprimary_K0star.pdf
-rm dpl-config.json
+rm -f dpl-config.json
+

--- a/codeHF/clean.sh
+++ b/codeHF/clean.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-echo "Cleaning"
+echo -e "\nCleaning"
 
 rm -f *.root
 rm -f *.txt
-rm -f output*
 rm -f *.pdf
+rm -f *.log
+rm -f output*
 rm -f localhost*
 git checkout cv_K0star.pdf
 git checkout cvprimary_K0star.pdf

--- a/codeHF/runtest_new.sh
+++ b/codeHF/runtest_new.sh
@@ -3,6 +3,7 @@
 bash clean.sh
 
 CASE=4
+
 DOCONVERT=1 # Convert AliESDs.root to AO2D.root.
 DORUN1=1 # Run the tasks with AliPhysics.
 DORUN3=1 # Run the tasks with O2.
@@ -77,49 +78,93 @@ fi
 #INPUTDIR="/data/Run3data/alice_sim_2018_LHC18a4a2_cent/282099" #D2H MC sample
 #INPUTDIR="/data/Run3data/alice_sim_2015_LHC15k1a3_246391/246391" #HIJING MC PbPb
 
-rm -f *.root
-rm -f *.txt
+# List of input files
+ls $INPUTDIR/$STRING > $LISTNAME
+
+# Output files
+FILEOUTALI="Vertices2prong-ITS1.root"
+FILEOUTO2="AnalysisResults.root"
+
+# Steering commands
+ENVALI="alienv setenv AliPhysics/latest -c"
+ENVO2="alienv setenv O2/latest -c"
+CMDROOT="root -b -q -l"
 
 # Convert AliESDs.root to AO2D.root.
 if [ $DOCONVERT -eq 1 ]; then
-  rm -f $LISTNAME
-  ls $INPUTDIR/$STRING >> $LISTNAME
-  echo $LISTNAME
-  root -b -q -l "convertAO2D.C(\"$LISTNAME\", $ISMC, $NMAX)"
-  mv AO2D.root $AOD3NAME
+  LOGFILE="log_convert.log"
+  echo -e "\nConverting... (logfile: $LOGFILE)"
+  echo "Input files taken from: $LISTNAME"
+  $ENVALI $CMDROOT "convertAO2D.C(\"$LISTNAME\", $ISMC, $NMAX)" > $LOGFILE 2>&1
+  if [ ! $? -eq 0 ]; then echo "Error"; exit 1; fi # Exit if error.
+  rm -f $FILEOUTO2
+  #mv AO2D.root $AOD3NAME
 fi
 
 # Run the tasks with AliPhysics.
 if [ $DORUN1 -eq 1 ]; then
+  LOGFILE="log_ali.log"
+  echo -e "\nRunning the tasks with AliPhysics... (logfile: $LOGFILE)"
   rm -f Vertices2prong-ITS1_*.root
   fileouttxt="outputlist.txt"
   rm -f $fileouttxt
+  rm -f $LOGFILE
 
   index=0
   while read F  ; do
     fileout="Vertices2prong-ITS1_$index.root"
     rm -f "$fileout"
     echo $fileout >> "$fileouttxt"
-    echo "$F"
-    echo "$fileout"
-    root -b -q -l "ComputeVerticesRun1_Opt.C(\"$F\",\"$fileout\",\"$JSON\")"
+    echo "Index $index"
+    echo "Input file: $F"
+    echo "Output file: $fileout"
+    $ENVALI $CMDROOT "ComputeVerticesRun1_Opt.C(\"$F\",\"$fileout\",\"$JSON\")" >> $LOGFILE 2>&1
+    if [ ! $? -eq 0 ]; then echo "Error"; exit 1; fi # Exit if error.
     index=$((index+1))
-    echo $index
   done <"$LISTNAME"
-  rm -f "Vertices2prong-ITS1.root"
-  hadd Vertices2prong-ITS1.root @"$fileouttxt"
+  rm -f $FILEOUTALI
+  echo "Merging output files..."
+  $ENVALI hadd $FILEOUTALI @"$fileouttxt" >> $LOGFILE 2>&1
+  if [ ! $? -eq 0 ]; then echo "Error"; exit 1; fi # Exit if error.
 fi
 
 # Run the tasks with O2.
 if [ $DORUN3 -eq 1 ]; then
-  rm -f AnalysisResults.root
+  LOGFILE="log_o2.log"
+  echo -e "\nRunning the tasks with O2... (logfile: $LOGFILE)"
+  rm -f $FILEOUTO2
+  if [ ! -f "$AOD3NAME" ]; then
+    echo "Error: File $AOD3NAME does not exist."
+    exit 1
+  fi
   O2ARGS="--shm-segment-size 16000000000 --configuration json://$PWD/dpl-config_std.json --aod-file $AOD3NAME"
-  o2-analysis-hftrackindexskimscreator $O2ARGS | o2-analysis-hfcandidatecreator2prong $O2ARGS | o2-analysis-taskdzero $O2ARGS -b
-  #o2-analysis-vertexing-hf --aod-file $AOD3NAME  -b --triggerindex=$TRIGGERBITRUN3
+  O2EXEC="o2-analysis-hftrackindexskimscreator $O2ARGS | o2-analysis-hfcandidatecreator2prong $O2ARGS | o2-analysis-taskdzero $O2ARGS -b"
+  TMPSCRIPT="tmpscript.sh"
+  cat << EOF > $TMPSCRIPT # Create a temporary script with the full O2 commands.
+#!/bin/bash
+$O2EXEC
+EOF
+  $ENVO2 bash $TMPSCRIPT > $LOGFILE 2>&1 # Run the script in the O2 environment.
+  if [ ! $? -eq 0 ]; then echo "Error"; exit 1; fi # Exit if error.
+  rm -f $TMPSCRIPT
 fi
 
 # Compare AliPhysics and O2 output.
 if [ $DOCOMPARE -eq 1 ]; then
-  root -b -q -l "CompareNew.C(\"AnalysisResults.root\",\"Vertices2prong-ITS1.root\", $MASS)"
+  LOGFILE="log_compare.log"
+  echo -e "\nComparing... (logfile: $LOGFILE)"
+  ok=1
+  for file in "$FILEOUTALI" "$FILEOUTO2"; do
+    if [ ! -f "$file" ]; then
+      echo "Error: File $file does not exist."
+      ok=0
+    fi
+  done
+  if [ ! $ok -eq 1 ]; then exit 1; fi
+  $ENVALI $CMDROOT "CompareNew.C(\"$FILEOUTO2\",\"$FILEOUTALI\", $MASS)" > $LOGFILE 2>&1
+  if [ ! $? -eq 0 ]; then echo "Error"; exit 1; fi # Exit if error.
 fi
+
+echo -e "\nDone"
+exit 0
 


### PR DESCRIPTION
- Clean before running.
- Suppress rm complains.
- Run ROOT in batch mode.
- Add comments.
- Factorise out repeated O2 commands arguments.
- Improve log messages.
- Standardise return values of ROOT macros to allow catching errors.
- Factorise out repeated commands and strings.
- Run AliPhysics, hadd and O2 in separate environments (no need to load the environment before running the script).
- Redirect std and err output of AliPhysics, hadd and O2 into separate log files for each step.
- Remove unnecessary commands.
- Check for missing input files.
- Remove AnalysisResults.root produced by conversion to avoid using it by CompareNew.C when DORUN3=0 and DOCOMPARE=1.
- Create the LISTNAME input list independently of DOCONVERT to allow running DORUN1 alone.
- Exit immediately if any step fails.